### PR TITLE
Develop

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -73,19 +73,16 @@ Special commands:
 				}
 			}
 
+			// Search
+			if !searchFlag {
+				// if search flag are not set, check if they are enabled globally
+				searchFlag = IsSearchEnabled()
+			}
+
+			// Tools
 			if !toolsFlag {
 				// if tools flag are not set, check if they are enabled globally
 				toolsFlag = AreToolsEnabled()
-			}
-			// Set whether or not to use tools
-			SetToolsEnabled(toolsFlag)
-
-			if cmd.Flags().Changed("search") {
-				// Search mode
-				SetEffectSearchEnginelName(searchFlag)
-			} else {
-				// Normal mode
-				searchFlag = ""
 			}
 
 			// Always save a conversation file regardless of the flag
@@ -138,7 +135,7 @@ func init() {
 	chatCmd.Flags().StringVarP(&templateFlag, "template", "p", "", "Template to use for the chat session")
 	chatCmd.Flags().StringSliceVarP(&attachments, "attachment", "a", []string{}, "Specify file(s) or image(s) to append to the chat sessioin")
 	chatCmd.Flags().StringVarP(&convoName, "conversation", "c", GenerateChatFilename(), "Name for this chat session")
-	chatCmd.Flags().StringVarP(&searchFlag, "search", "s", service.GetDefaultSearchEngineName(), "Search engine for the chat session")
+	chatCmd.Flags().BoolVarP(&searchFlag, "search", "s", false, "Search engine for the chat session")
 	chatCmd.Flags().BoolVarP(&toolsFlag, "tools", "t", true, "Enable or disable tools for the chat session")
 	chatCmd.Flags().Lookup("search").NoOptDefVal = service.GetDefaultSearchEngineName()
 	chatCmd.Flags().IntVarP(&referenceFlag, "reference", "r", 5, "Specify the number of reference links to show")
@@ -307,11 +304,15 @@ func (ci *ChatInfo) setSystem(system string) {
 }
 
 func (ci *ChatInfo) setSearchEngine(engine string) {
-	succeed := SetEffectSearchEnginelName(engine)
+	succeed := SetEffectSearchEngineName(engine)
 	if succeed {
-		searchFlag = GetEffectSearchEnginelName()
 		fmt.Printf("Switched to search engine: %s\n", engine)
 	}
+}
+
+func (ci *ChatInfo) printSearchEngine() {
+	name := GetEffectSearchEngineName()
+	fmt.Printf("Current search engine: %s\n", name)
 }
 
 func (ci *ChatInfo) setReferences(count string) {
@@ -473,7 +474,7 @@ func (ci *ChatInfo) showInfo() {
 	fmt.Printf("  Model: %s\n", ci.Model)
 	fmt.Printf("  System Prompt: \n    - %s\n", GetEffectiveSystemPrompt())
 	fmt.Printf("  Template: \n    - %s\n", GetEffectiveTemplate())
-	fmt.Printf("  Search Engine: %s\n", GetEffectSearchEnginelName())
+	fmt.Printf("  Search Engine: %s\n", GetEffectSearchEngineName())
 	fmt.Printf("  Use Tools: %t\n", AreToolsEnabled())
 	fmt.Printf("  Usage Metainfo: %s\n", GetUsageMetainfoStatus())
 	fmt.Printf("  Attachment(s): \n")
@@ -641,6 +642,7 @@ func (ci *ChatInfo) handleCommand(cmd string) {
 	case "/search", "/s":
 		if len(parts) < 2 {
 			fmt.Println("Please specify a search engine. Options: google, tavily, bing, none")
+			ci.printSearchEngine()
 			return
 		}
 		engine := strings.TrimSpace(parts[1])
@@ -701,16 +703,15 @@ func (ci *ChatInfo) callLLM(input string) {
 	_, modelInfo := GetEffectiveModel()
 	sys_prompt := GetEffectiveSystemPrompt()
 
-	// Check whether to use tools
-	useTools := AreToolsEnabled()
-
 	// If tools are enabled, we will use the search engine
 	// If search flag is set, we will use the search engine, too
 	var searchEngine map[string]any
-	if searchFlag != "" || useTools {
+	if searchFlag || toolsFlag {
 		_, searchEngine = GetEffectiveSearchEngine()
-		searchEngine["deep_dive"] = deepDiveFlag   // Add deep dive flag to search engine settings
-		searchEngine["references"] = referenceFlag // Add references flag to search engine settings
+		if searchEngine != nil {
+			searchEngine["deep_dive"] = deepDiveFlag   // Add deep dive flag to search engine settings
+			searchEngine["references"] = referenceFlag // Add references flag to search engine settings
+		}
 	}
 
 	// Include usage metainfo
@@ -725,7 +726,7 @@ func (ci *ChatInfo) callLLM(input string) {
 		ModelInfo:        &modelInfo,
 		SearchEngine:     &searchEngine,
 		MaxRecursions:    ci.maxRecursions,
-		UseTools:         useTools,
+		UseTools:         toolsFlag,
 		SkipToolsConfirm: confirmToolsFlag,
 		AppendUsage:      includeUsage,
 		AppendMarkdown:   includeMarkdown,

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -122,6 +122,10 @@ Special commands:
 
 var ()
 
+const (
+	_gllmChatPrompt = "\033[96mgllm>\033[0m "
+)
+
 func init() {
 	rootCmd.AddCommand(chatCmd)
 
@@ -150,7 +154,7 @@ func (ci *ChatInfo) startREPL() {
 	ci.showHelp()
 	fmt.Println()
 
-	rl, err := readline.New("gllm> ")
+	rl, err := readline.New(_gllmChatPrompt)
 	if err != nil {
 		fmt.Printf("Error initializing readline: %v\n", err)
 		return
@@ -161,7 +165,7 @@ func (ci *ChatInfo) startREPL() {
 	multilineMode := false
 
 	for {
-		prompt := "gllm> "
+		prompt := _gllmChatPrompt
 		if multilineMode {
 			prompt = "... "
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -213,7 +213,7 @@ var configPrintCmd = &cobra.Command{
 		searchEngines := GetAllSearchEngines()
 		fmt.Fprintln(w, headerColor(" Search ")+"\t"+headerColor(" SETTINGS "))
 		fmt.Fprintln(w, headerColor("-------")+"\t"+headerColor("----------"))
-		defaultSearch := GetEffectSearchEnginelName()
+		defaultSearch := GetEffectSearchEngineName()
 		for name, settings := range searchEngines {
 			coloredName := name
 			if name == defaultSearch {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -305,13 +305,13 @@ func GetEffectSearchEngineName() string {
 func SetEffectSearchEngineName(name string) bool {
 	switch name {
 	case service.GoogleSearchEngine:
-		viper.Set("agent.search", "google")
+		viper.Set("agent.search", service.GoogleSearchEngine)
 	case service.TavilySearchEngine:
-		viper.Set("agent.search", "tavily")
+		viper.Set("agent.search", service.TavilySearchEngine)
 	case service.BingSearchEngine:
-		viper.Set("agent.search", "bing")
-	case service.NoneSearchEngine:
-		viper.Set("agent.search", "none")
+		viper.Set("agent.search", service.BingSearchEngine)
+	case service.DummySearchEngine:
+		viper.Set("agent.search", service.DummySearchEngine)
 	default:
 		service.Warnf("Error: '%s' is not a valid search engine. Options: google, tavily, bing, none", name)
 		return false

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -16,6 +16,16 @@ var searchCmd = &cobra.Command{
 	Short: "Configure and manage search engines globally",
 	Long: `Configure API keys and settings for various search engines used with gllm.
 You can switch on/off whether to use search engines`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(cmd.Long)
+		defaultEngine := viper.GetString("agent.search")
+		fmt.Println()
+		if defaultEngine != "" {
+			fmt.Printf("Current search engine set to %s\n", switchOnColor+defaultEngine+resetColor)
+		} else {
+			fmt.Println("No search engine set.")
+		}
+	},
 }
 
 // searchOnCmd represents the command to turn on a specific search engine

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -13,8 +13,55 @@ import (
 // searchCmd represents the search command
 var searchCmd = &cobra.Command{
 	Use:   "search",
-	Short: "Configure and manage search engines",
-	Long:  `Configure API keys and settings for various search engines used with gllm.`,
+	Short: "Configure and manage search engines globally",
+	Long: `Configure API keys and settings for various search engines used with gllm.
+You can switch on/off whether to use search engines`,
+}
+
+// searchOnCmd represents the command to turn on a specific search engine
+var searchOnCmd = &cobra.Command{
+	Use:   "on",
+	Short: "Turn on a specific search engine",
+	Long: `Turn on a specific search engine to be used.
+Available search engines: google, tavily, bing`,
+	Run: func(cmd *cobra.Command, args []string) {
+		engine := ""
+		// Display current default if no arguments provided
+		if len(args) == 0 {
+			engine = viper.GetString("agent.search")
+			if engine == "" {
+				engine = "google"
+				fmt.Print("No default search engine set.\nUse google as default.\nAvailable options: google, tavily, bing\n\n")
+			} else {
+				fmt.Printf("Search engine turned "+switchOnColor+"on"+resetColor+": %s\n", switchOnColor+engine+resetColor)
+				return
+			}
+		}
+
+		// Set new default
+		if engine == "" {
+			engine = strings.ToLower(args[0])
+		}
+		if engine != "google" && engine != "tavily" && engine != "bing" {
+			service.Errorf("Error: '%s' is not a valid search engine. Options: google, tavily, bing\n", engine)
+			return
+		}
+
+		// Check if the selected engine is configured
+		key := viper.GetString(fmt.Sprintf("search_engines.%s.key", engine))
+		if key == "" {
+			service.Warnf("Warning: %s is not yet configured. Please set API key first.", engine)
+			return
+		}
+
+		viper.Set("agent.search", engine)
+		if err := viper.WriteConfig(); err != nil {
+			service.Errorf("Error saving configuration: %s\n", err)
+			return
+		}
+
+		fmt.Printf("Search engine turned "+switchOnColor+"on"+resetColor+": %s\n", switchOnColor+engine+resetColor)
+	},
 }
 
 // searchGoogleCmd represents the google search command
@@ -158,58 +205,33 @@ var searchListCmd = &cobra.Command{
 			fmt.Println("Use 'gllm search [engine] --key YOUR_KEY' to configure.")
 		}
 
+		fmt.Println("-------------------------")
+
 		// Update the list command to show default status
 		// In the listCmd.Run function, add:
 		defaultEngine := viper.GetString("agent.search")
 		fmt.Println()
 		if defaultEngine != "" {
-			fmt.Printf("Default search engine:%s\n", defaultEngine)
+			fmt.Printf("Current search engine set to %s\n", switchOnColor+defaultEngine+resetColor)
 		} else {
-			fmt.Println("No default search engine set.")
+			fmt.Println("No search engine set.")
 		}
-		fmt.Println("-------------------------")
 	},
 }
 
-// searchDefaultCmd represents the command to set default search engine
-var searchDefaultCmd = &cobra.Command{
-	Use:     "default",
-	Aliases: []string{"def"},
-	Short:   "Set the default search engine",
-	Long:    `Set which search engine to use by default when performing searches(RAG).`,
+// searchOffCmd represents the command to turn off search engine
+var searchOffCmd = &cobra.Command{
+	Use:   "off",
+	Short: "Turn off search engine",
+	Long:  `Turn off search engine, agent would not do any search.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Display current default if no arguments provided
-		if len(args) == 0 {
-			current := viper.GetString("agent.search")
-			if current == "" {
-				fmt.Println("No default search engine set. Available options: google, tavily, bing, none")
-			} else {
-				fmt.Printf("Current default search engine: %s\n", current)
-			}
-			return
-		}
-
-		// Set new default
-		engine := strings.ToLower(args[0])
-		if engine != "google" && engine != "tavily" && engine != "bing" && engine != "none" {
-			service.Errorf("Error: '%s' is not a valid search engine. Options: google, tavily, bing, none\n", engine)
-			return
-		}
-
-		// Check if the selected engine is configured
-		key := viper.GetString(fmt.Sprintf("search_engines.%s.key", engine))
-		if key == "" {
-			service.Warnf("Warning: %s is not yet configured. Please set API key first.", engine)
-			return
-		}
-
-		viper.Set("agent.search", engine)
+		viper.Set("agent.search", "")
 		if err := viper.WriteConfig(); err != nil {
 			service.Errorf("Error saving configuration: %s\n", err)
 			return
 		}
 
-		fmt.Printf("Default search engine set to: %s\n", engine)
+		fmt.Println("Search engine is turned " + switchOffColor + "off" + resetColor)
 	},
 }
 
@@ -271,12 +293,16 @@ func maskAPIKey(key string) string {
 	*/
 }
 
-func GetEffectSearchEnginelName() string {
+func IsSearchEnabled() bool {
+	return GetEffectSearchEngineName() != ""
+}
+
+func GetEffectSearchEngineName() string {
 	defaultName := viper.GetString("agent.search")
 	return defaultName
 }
 
-func SetEffectSearchEnginelName(name string) bool {
+func SetEffectSearchEngineName(name string) bool {
 	switch name {
 	case service.GoogleSearchEngine:
 		viper.Set("agent.search", "google")
@@ -352,7 +378,8 @@ func init() {
 	searchCmd.AddCommand(searchTavilyCmd)
 	searchCmd.AddCommand(searchBingCmd)
 	searchCmd.AddCommand(searchListCmd)
-	searchCmd.AddCommand(searchDefaultCmd)
+	searchCmd.AddCommand(searchOnCmd)
+	searchCmd.AddCommand(searchOffCmd)
 	searchCmd.AddCommand(searchSaveCmd)
 
 	// Google flags

--- a/cmd/tools.go
+++ b/cmd/tools.go
@@ -10,7 +10,7 @@ import (
 
 var toolsCmd = &cobra.Command{
 	Use:   "tools",
-	Short: "Enable/Disable embedding tools",
+	Short: "Enable/Disable embedding tools globally",
 	Long: `Tools give gllm the ability to interact with the file system, execute commands, and perform other operations.
 By default, all tools are enabled. You can disable these tools.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Hardcode the version string here
-const version = "v1.9.7" // <<< Set your desired version
+const version = "v1.9.8" // <<< Set your desired version
 
 func init() {
 	rootCmd.AddCommand(versionCmd)

--- a/service/gemini2.go
+++ b/service/gemini2.go
@@ -205,7 +205,8 @@ func (ag *Agent) GenerateGemini2Stream() error {
 		ag.TokenUsage.RecordTokenUsage(int(finalResp.UsageMetadata.PromptTokenCount),
 			int(finalResp.UsageMetadata.CandidatesTokenCount),
 			int(finalResp.UsageMetadata.CachedContentTokenCount),
-			int(finalResp.UsageMetadata.ThoughtsTokenCount))
+			int(finalResp.UsageMetadata.ThoughtsTokenCount),
+			int(finalResp.UsageMetadata.TotalTokenCount))
 	}
 
 	// Save the conversation history

--- a/service/gemini2.go
+++ b/service/gemini2.go
@@ -116,7 +116,12 @@ func (ag *Agent) GenerateGemini2Stream() error {
 		config.Tools = append(config.Tools, ag.getGemini2CodeExecTool())
 	}
 
-	// Create a chat session
+	// Create a chat session - this is the important part
+	// Within the chat session(multi-turn conversation)
+	// we still need to sent the entire history to the model
+	// but it won't consume tokens, because it was cached in local and remote server
+	// so gemini model would fast load the cached history KV
+	// it will only consume tokens on new input
 	chat, err := client.Chats.Create(ctx, ag.ModelName, &config, convo.History)
 	if err != nil {
 		ag.Status.ChangeTo(ag.NotifyChan, StreamNotify{Status: StatusError, Data: fmt.Sprintf("Failed to create chat: %v", err)}, nil)

--- a/service/gemini2.go
+++ b/service/gemini2.go
@@ -39,6 +39,19 @@ func (ag *Agent) getGemini2FilePart(file *FileData) genai.Part {
 	}
 }
 
+// func (ag *Agent) InitGemini2Agent() error {
+// 	// Setup the Gemini client
+// 	ctx := context.Background()
+// 	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+// 		APIKey:  ag.ApiKey,
+// 		Backend: genai.BackendGeminiAPI,
+// 	})
+// 	if err != nil {
+// 		ag.Status.ChangeTo(ag.NotifyChan, StreamNotify{Status: StatusError, Data: fmt.Sprintf("Failed to create client: %v", err)}, nil)
+// 		return err
+// 	}
+// }
+
 func (ag *Agent) GenerateGemini2Stream() error {
 	// Setup the Gemini client
 	ctx := context.Background()

--- a/service/gemini2.go
+++ b/service/gemini2.go
@@ -209,7 +209,7 @@ func (ag *Agent) GenerateGemini2Stream() error {
 
 	// Add references to the output if any
 	if len(references) > 0 {
-		refs := "\n\n" + ag.SearchEngine.RetrieveReferences(references) + "\n"
+		refs := "\n\n" + ag.SearchEngine.RetrieveReferences(references)
 		ag.DataChan <- StreamData{Text: refs, Type: DataTypeNormal}
 	}
 

--- a/service/openchat.go
+++ b/service/openchat.go
@@ -47,6 +47,17 @@ func (ag *Agent) getOpenChatFilePart(file *FileData) *model.ChatCompletionMessag
 	return part
 }
 
+// func (ag *Agent) InitOpenChatAgent() error {
+// 	// 1. Initialize the Client
+// 	ctx := context.Background()
+// 	// Create a client config with custom base URL
+// 	client := arkruntime.NewClientWithApiKey(
+// 		ag.ApiKey,
+// 		arkruntime.WithTimeout(30*time.Minute),
+// 		arkruntime.WithBaseUrl(ag.EndPoint),
+// 	)
+// }
+
 func (ag *Agent) GenerateOpenChatStream() error {
 
 	// 1. Initialize the Client

--- a/service/openchat.go
+++ b/service/openchat.go
@@ -248,7 +248,7 @@ func (c *OpenChat) process(ag *Agent) error {
 	}
 	// Add references to the output if any
 	if len(c.references) > 0 {
-		refs := "\n\n" + ag.SearchEngine.RetrieveReferences(c.references) + "\n"
+		refs := "\n\n" + ag.SearchEngine.RetrieveReferences(c.references)
 		c.data <- StreamData{Text: refs, Type: DataTypeNormal}
 	}
 

--- a/service/openchat.go
+++ b/service/openchat.go
@@ -246,7 +246,8 @@ func (c *OpenChat) process(ag *Agent) error {
 		ag.TokenUsage.RecordTokenUsage(int(finalResp.Usage.PromptTokens),
 			int(finalResp.Usage.CompletionTokens),
 			int(finalResp.Usage.PromptTokensDetails.CachedTokens),
-			int(finalResp.Usage.CompletionTokensDetails.ReasoningTokens))
+			int(finalResp.Usage.CompletionTokensDetails.ReasoningTokens),
+			int(finalResp.Usage.TotalTokens))
 	}
 
 	// No more message

--- a/service/search.go
+++ b/service/search.go
@@ -49,7 +49,7 @@ const (
 	GoogleSearchEngine = "google"
 	BingSearchEngine   = "bing"
 	TavilySearchEngine = "tavily"
-	NoneSearchEngine   = "none"
+	DummySearchEngine  = "dummy"
 )
 
 type SearchEngine struct {
@@ -71,9 +71,9 @@ func GetDefaultSearchEngineName() string {
 	return GoogleSearchEngine
 }
 
-func GetNoneSearchEngineName() string {
+func GetDummySearchEngineName() string {
 	// Using for placeholder
-	return NoneSearchEngine
+	return DummySearchEngine
 }
 
 func (s *SearchEngine) TavilySearch(query string) (map[string]any, error) {

--- a/service/tools.go
+++ b/service/tools.go
@@ -1184,7 +1184,7 @@ func (c *OpenChat) processWebSearchToolCall(toolCall *model.ToolCall, argsMap *m
 	case TavilySearchEngine:
 		// Use Tavily Search Engine
 		data, err = c.search.TavilySearch(query)
-	case NoneSearchEngine:
+	case DummySearchEngine:
 		// Use None Search Engine
 		data, err = c.search.NoneSearch(query)
 	default:

--- a/service/usage.go
+++ b/service/usage.go
@@ -94,10 +94,10 @@ func (tu *TokenUsage) Render(render Render) {
 	render.Writeln(usage)
 }
 
-func (tu *TokenUsage) RecordTokenUsage(input, output, cached, thought int) {
+func (tu *TokenUsage) RecordTokenUsage(input, output, cached, thought, total int) {
 	tu.InputTokens = input
 	tu.OutputTokens = output
 	tu.CachedTokens = cached
 	tu.ThoughtTokens = thought
-	tu.TotalTokens = tu.InputTokens + tu.OutputTokens + tu.CachedTokens + tu.ThoughtTokens
+	tu.TotalTokens = total
 }


### PR DESCRIPTION
- In both Gemini2 and OpenChat services, remove the trailing newline from the references section
- This change ensures consistency in the formatting of reference sections across different services