### PR TITLE
feat: refactor edit_file tool to use search-replace operations

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Hardcode the version string here
-const version = "v1.12.1" // <<< Set your desired version
+const version = "v1.12.2" // <<< Set your desired version
 
 func init() {
 	rootCmd.AddCommand(versionCmd)

--- a/service/gemini2.go
+++ b/service/gemini2.go
@@ -333,7 +333,7 @@ func (ag *Agent) processGemini2ToolCall(call *genai.FunctionCall) (*genai.Functi
 	var args string
 	if call.Name == "edit_file" || call.Name == "write_file" {
 		// Don't show content(the modified content could be too long)
-		args = formatToolCallArguments(call.Args, []string{"content"})
+		args = formatToolCallArguments(call.Args, []string{"content", "edits"})
 	} else {
 		args = formatToolCallArguments(call.Args, []string{})
 	}

--- a/service/openai.go
+++ b/service/openai.go
@@ -397,7 +397,7 @@ func (oa *OpenAI) processToolCall(toolCall openai.ToolCall) (openai.ChatCompleti
 	var args string
 	if toolCall.Function.Name == "edit_file" || toolCall.Function.Name == "write_file" {
 		// Don't show content(the modified content could be too long)
-		args = formatToolCallArguments(argsMap, []string{"content"})
+		args = formatToolCallArguments(argsMap, []string{"content", "edits"})
 	} else {
 		args = formatToolCallArguments(argsMap, []string{})
 	}

--- a/service/openchat.go
+++ b/service/openchat.go
@@ -434,7 +434,7 @@ func (c *OpenChat) processToolCall(toolCall model.ToolCall) (*model.ChatCompleti
 	var args string
 	if toolCall.Function.Name == "edit_file" || toolCall.Function.Name == "write_file" {
 		// Don't show content(the modified content could be too long)
-		args = formatToolCallArguments(argsMap, []string{"content"})
+		args = formatToolCallArguments(argsMap, []string{"content", "edits"})
 	} else {
 		args = formatToolCallArguments(argsMap, []string{})
 	}


### PR DESCRIPTION
- Updated edit_file function in opentools.go to apply targeted edits via search-replace arrays instead of overwriting entire file content, improving precision and safety for code modifications.
- Modified tool call processing in gemini2.go, openai.go, and openchat.go to exclude "edits" from argument logging alongside "content".
- Bumped version from v1.12.1 to v1.12.2 in version.go.