### PR TITLE
feat: default to chat mode and rename chat to repl/session

### DIFF
--- a/cmd/convo.go
+++ b/cmd/convo.go
@@ -21,7 +21,7 @@ var (
 
 // convoCmd represents the convo command
 var convoCmd = &cobra.Command{
-	Use:     "convo",
+	Use:     "session",
 	Aliases: []string{"cv", "conversation"},
 	Short:   "Manage conversations",
 	Long:    `Commands to list, remove, and show details of conversations.`,

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -19,12 +19,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// chatCmd represents the chat command
-var chatCmd = &cobra.Command{
-	Use:    "chat",
-	Short:  "Start an interactive chat session (REPL)",
+// replCmd represents the repl command
+var replCmd = &cobra.Command{
+	Use:    "repl",
+	Short:  "Start an interactive REPL session",
 	Hidden: true, // users invoke this implicitly via `gllm` with no subcommand
-	Long: `Start an interactive chat session with the configured LLM.
+	Long: `Start an interactive REPL session with the configured LLM.
 This provides a Read-Eval-Print-Loop (REPL) interface where you can
 have a continuous conversation with the model.`,
 	// Add completion support
@@ -41,16 +41,16 @@ have a continuous conversation with the model.`,
 		// Clear empty conversations in background
 		// service.ClearEmptyConvosAsync()
 
-		var chatInfo *ChatInfo
+		var ri *ReplInfo
 		store := data.NewConfigStore()
 
 		// Use the shared package-level convoName/agentName globals so that flags
-		// declared on rootCmd (e.g. -c, -g) are correctly honored when chatCmd
+		// declared on rootCmd (e.g. -c, -g) are correctly honored when replCmd
 		// is invoked programmatically from rootCmd's Run handler.
 
 		// If a conversation name was not supplied, generate a fresh one.
 		if convoName == "" {
-			convoName = GenerateChatFileName()
+			convoName = GenerateSessionName()
 		} else {
 			// Resolve index-based names to their canonical file name.
 			name, err := service.FindConvosByIndex(convoName)
@@ -70,15 +70,15 @@ have a continuous conversation with the model.`,
 			store.SetActiveAgent(agentName)
 		}
 
-		// Build the ChatInfo object
-		chatInfo = &ChatInfo{
+		// Build the ReplInfo object
+		ri = &ReplInfo{
 			QuitFlag: false,
 		}
 
 		ui.GetIndicator().Stop()
 
 		// Start the REPL
-		chatInfo.startREPL()
+		ri.startREPL()
 		return nil
 	},
 }
@@ -86,33 +86,32 @@ have a continuous conversation with the model.`,
 var ()
 
 const (
-	chatEidtTempFile = ".gllm-edit-*.tmp"
+	editTempFile = ".gllm-edit-*.tmp"
 )
 
 // Load when package is initialized
 func init() {
-	rootCmd.AddCommand(chatCmd)
+	rootCmd.AddCommand(replCmd)
 
-	// Add chat-specific flags
-	// In each chat session, it shouldn't change model, because the chat history would be invalid.
-	// Attach should be used inside chat session
-	// Imagine like using web llm ui, you can attach file to the chat session and turn search on and off
-	chatCmd.Flags().StringVarP(&agentName, "agent", "g", "", "Agent to use for the chat session")
-	chatCmd.Flags().StringVarP(&convoName, "conversation", "c", GenerateChatFileName(), "Name for this chat session")
-	chatCmd.Flags().BoolVarP(&yoloFlag, "yolo", "y", false, "Enable yolo mode (non-interactive)")
+	// Add session specific flags
+	// Attach should be used inside session
+	// Imagine like using web llm ui, you can attach file to the session and turn search on and off
+	replCmd.Flags().StringVarP(&agentName, "agent", "g", "", "Agent to use for this session")
+	replCmd.Flags().StringVarP(&convoName, "conversation", "c", GenerateSessionName(), "Name for this session")
+	replCmd.Flags().BoolVarP(&yoloFlag, "yolo", "y", false, "Enable yolo mode (non-interactive)")
 }
 
-type ChatInfo struct {
+type ReplInfo struct {
 	Files       []*service.FileData
 	QuitFlag    bool     // for cmd /quit or /exit
 	EditorInput string   // for /e editor edit
 	Instruction string   // for underlying system instructions (e.g. skill activation)
-	History     []string // for chat input history
+	History     []string // for input history
 	outputFile  string
 	sharedState *data.SharedState // Persistent SharedState for the session
 }
 
-func (ci *ChatInfo) printWelcome() {
+func (ri *ReplInfo) printWelcome() {
 	termWidth := ui.GetTerminalWidth()
 	safeWidth := max(40, termWidth-4)
 
@@ -147,13 +146,13 @@ func (ci *ChatInfo) printWelcome() {
 		Italic(true)
 
 	logo := ui.GetLogo(data.KeyHex, data.LabelHex, 0.5)
-	welcomeText := logo + "\nWelcome to Chat Mode" + " (v" + version + ")"
+	welcomeText := logo + "\nWelcome back!" + data.DetailColor + " (v" + version + ")" + data.ResetSeq
 	instructions := []string{
-		"• '/help' lists all available commands",
-		"• '/exit', '/quit' to end current chat session",
 		"• Ctrl+C to cancel, Ctrl+D to clear the input",
 		"• '/' for commands, '!' for local shell commands",
 		"• '@' for files and folders",
+		"• '/help' lists all available commands",
+		"• '/exit', '/quit' to end current session",
 	}
 
 	header := headerStyle.Render(welcomeText)
@@ -171,7 +170,7 @@ func (ci *ChatInfo) printWelcome() {
 }
 
 // This is the legacy awaitChat function, which uses huh, don't support auto-complete
-func (ci *ChatInfo) awaitChat_legacy() (string, error) {
+func (ri *ReplInfo) awaitChat_legacy() (string, error) {
 	var input string
 
 	form := huh.NewForm(
@@ -190,26 +189,26 @@ func (ci *ChatInfo) awaitChat_legacy() (string, error) {
 	return strings.TrimSpace(input), nil
 }
 
-// This is the new awaitChat function, which uses bubbletea, support auto-complete
-func (ci *ChatInfo) awaitChat() (string, error) {
+// This is the new awaitInput function, which uses bubbletea, support auto-complete
+func (ri *ReplInfo) awaitInput() (string, error) {
 	agent, err := EnsureActiveAgent()
 	if err != nil {
 		return "", err
 	}
 
 	var commands []ui.Suggestion
-	for cmd, desc := range chatCommandMap {
+	for cmd, desc := range replCommandMap {
 		commands = append(commands, ui.Suggestion{Command: cmd, Description: desc})
 	}
 
 	// Load workflow commands
-	_ = service.GetWorkflowManager().LoadMetadata(chatCommandMap)
+	_ = service.GetWorkflowManager().LoadMetadata(replCommandMap)
 
 	// Add workflow commands
 	wm := service.GetWorkflowManager()
 	for cmd, desc := range wm.GetCommands() {
-		// Skip if the command already exists in chatCommandMap
-		if _, ok := chatCommandMap[cmd]; ok {
+		// Skip if the command already exists in replCommandMap
+		if _, ok := replCommandMap[cmd]; ok {
 			continue
 		}
 		commands = append(commands, ui.Suggestion{Command: cmd, Description: desc})
@@ -222,8 +221,8 @@ func (ci *ChatInfo) awaitChat() (string, error) {
 
 		for _, skill := range skills {
 			cmdName := "/" + strings.ToLower(skill.Name)
-			// Skip if the command already exists in chatCommandMap or workflow cmds
-			if _, ok := chatCommandMap[cmdName]; ok {
+			// Skip if the command already exists in replCommandMap or workflow cmds
+			if _, ok := replCommandMap[cmdName]; ok {
 				continue
 			}
 
@@ -239,7 +238,7 @@ func (ci *ChatInfo) awaitChat() (string, error) {
 	})
 
 	// Run chat input
-	result, err := ui.RunChatInput(commands, ci.EditorInput, ci.History)
+	result, err := ui.RunChatInput(commands, ri.EditorInput, ri.History)
 	if err != nil {
 		return "", err
 	}
@@ -249,21 +248,21 @@ func (ci *ChatInfo) awaitChat() (string, error) {
 	}
 
 	// Update history
-	ci.History = result.History
+	ri.History = result.History
 
 	return result.Value, nil
 }
 
-func (ci *ChatInfo) startREPL() {
+func (ri *ReplInfo) startREPL() {
 	// Initialize SharedState for the session
-	ci.sharedState = data.NewSharedState()
-	defer ci.sharedState.Clear()
+	ri.sharedState = data.NewSharedState()
+	defer ri.sharedState.Clear()
 
 	// Set auto approve for the session
 	data.SetToolCallAutoApproveInSession(yoloFlag)
 
 	// Start the REPL
-	ci.printWelcome()
+	ri.printWelcome()
 
 	// Define prompt style
 	tcol := ui.GetTerminalWidth()
@@ -280,7 +279,7 @@ func (ci *ChatInfo) startREPL() {
 		var err error
 
 		// Get user input
-		input, err = ci.awaitChat()
+		input, err = ri.awaitInput()
 		if err != nil {
 			if service.IsUserCancelError(err) {
 				// Handle user cancellation (Ctrl+C)
@@ -295,20 +294,20 @@ func (ci *ChatInfo) startREPL() {
 		}
 
 		// Handle inner commands
-		if ci.startWithInnerCommand(input) {
+		if ri.startWithInnerCommand(input) {
 			// Reset editor input
-			ci.EditorInput = ""
+			ri.EditorInput = ""
 			// Handle inner command
-			ci.handleCommand(input)
-			if ci.QuitFlag {
+			ri.handleCommand(input)
+			if ri.QuitFlag {
 				break
 			}
 			fmt.Println()
 			// If editor input is not empty, use it as input
-			if ci.EditorInput != "" {
-				input = ci.EditorInput
+			if ri.EditorInput != "" {
+				input = ri.EditorInput
 				// Reset editor input
-				ci.EditorInput = ""
+				ri.EditorInput = ""
 			} else {
 				continue
 			}
@@ -318,32 +317,32 @@ func (ci *ChatInfo) startREPL() {
 		fmt.Println(promptStyle.Render(input))
 
 		// Handle shell commands
-		if ci.startWithLocalCommand(input) {
-			ci.executeShellCommand(input[1:])
+		if ri.startWithLocalCommand(input) {
+			ri.executeShellCommand(input[1:])
 			continue
 		}
 
 		// Call agent
-		ci.callAgent(input)
+		ri.callAgent(input)
 		fmt.Println()
 
-		// quit chat
-		if ci.QuitFlag {
+		// quit repl mode
+		if ri.QuitFlag {
 			break
 		}
 	}
 }
 
-func (ci *ChatInfo) startWithInnerCommand(line string) bool {
+func (ri *ReplInfo) startWithInnerCommand(line string) bool {
 	return strings.HasPrefix(line, "/")
 }
 
-func (ci *ChatInfo) startWithLocalCommand(line string) bool {
+func (ri *ReplInfo) startWithLocalCommand(line string) bool {
 	return strings.HasPrefix(line, "!")
 }
 
 // clearContext clears the conversation context
-func (ci *ChatInfo) clearContext() {
+func (ri *ReplInfo) clearContext() {
 	agent, err := EnsureActiveAgent()
 	if err != nil {
 		service.Errorf("%v", err)
@@ -362,12 +361,12 @@ func (ci *ChatInfo) clearContext() {
 		return
 	}
 	// Empty attachments
-	ci.Files = []*service.FileData{}
+	ri.Files = []*service.FileData{}
 	fmt.Printf("Context cleared.\n")
 }
 
 // showHistory displays conversation history using TUI viewport
-func (ci *ChatInfo) showHistory() {
+func (ri *ReplInfo) showHistory() {
 	// Get active agent
 	agent, err := EnsureActiveAgent()
 	if err != nil {
@@ -421,7 +420,7 @@ func (ci *ChatInfo) showHistory() {
 }
 
 // compressContext compresses the conversation context by replacing it with a summary
-func (ci *ChatInfo) compressContext() {
+func (ri *ReplInfo) compressContext() {
 	// Get active agent
 	agent, err := EnsureActiveAgent()
 	if err != nil {
@@ -467,25 +466,25 @@ func (ci *ChatInfo) compressContext() {
 	service.Successf("Compressed successfully!\nUse /history to view the compressed conversation.\n")
 }
 
-func (ci *ChatInfo) callAgent(input string) {
+func (ri *ReplInfo) callAgent(input string) {
 	prompt := input
-	if ci.Instruction != "" {
-		prompt = fmt.Sprintf("<instruction>\n%s\n</instruction>\n\n<user-request>%s</user-request>", ci.Instruction, input)
-		ci.Instruction = "" // Clear it after use
+	if ri.Instruction != "" {
+		prompt = fmt.Sprintf("<instruction>\n%s\n</instruction>\n\n<user-request>%s</user-request>", ri.Instruction, input)
+		ri.Instruction = "" // Clear it after use
 	}
 
 	// Call agent using the shared runner, passing persisted SharedState
-	err := RunAgent(prompt, ci.Files, convoName, ci.outputFile, ci.sharedState)
+	err := RunAgent(prompt, ri.Files, convoName, ri.outputFile, ri.sharedState)
 	if err != nil {
 		service.Errorf("%v", err)
 		return
 	}
 
 	// Reset the files after processing
-	ci.Files = []*service.FileData{}
+	ri.Files = []*service.FileData{}
 }
 
-func (ci *ChatInfo) executeShellCommand(command string) {
+func (ri *ReplInfo) executeShellCommand(command string) {
 	command = strings.TrimSpace(command)
 	if command == "" {
 		fmt.Println("No command provided")
@@ -519,12 +518,12 @@ func (ci *ChatInfo) executeShellCommand(command string) {
 	}
 }
 
-func GenerateChatFileName() string {
+func GenerateSessionName() string {
 	// Get the current time
 	currentTime := time.Now()
 
 	// Format the time as a string in the format "chat_YYYY-MM-DD_HH-MM-SS.json"
-	filename := fmt.Sprintf("chat_%s", currentTime.Format("2006-01-02_15-04-05"))
+	filename := fmt.Sprintf("session-%s", currentTime.Format("2006-01-02_15-04-05"))
 
 	return filename
 }

--- a/cmd/replcmds.go
+++ b/cmd/replcmds.go
@@ -16,12 +16,12 @@ import (
 )
 
 var (
-	chatCommandMap = map[string]string{
-		"/exit":     "Exit the chat session",
-		"/quit":     "Exit the chat session",
+	replCommandMap = map[string]string{
+		"/exit":     "Exit current session",
+		"/quit":     "Exit current session",
 		"/help":     "Show this help message",
-		"/history":  "Show recent conversation history",
-		"/clear":    "Clear conversation history",
+		"/history":  "Show recent session history",
+		"/clear":    "Clear session history",
 		"/model":    "Manage models (list, switch, add, etc.)",
 		"/agent":    "Manage agents (list, switch, add, etc.)",
 		"/template": "Manage templates (list, switch, add, etc.)",
@@ -32,7 +32,7 @@ var (
 		"/skills":   "Manage agent skills (list, switch, install, etc.)",
 		"/memory":   "Manage memory (list, add, clear)",
 		"/yolo":     "Toggle YOLO mode",
-		"/convo":    "Manage conversations (list, info, remove, etc.)",
+		"/session":  "Manage sessions (list, info, remove, etc.)",
 		"/compress": "Compresses the context by replacing it with a summary",
 		"/think":    "Set thinking level",
 		"/features": "Switch agent features",
@@ -46,7 +46,7 @@ var (
 		"/workflow": "Manage workflow commands",
 	}
 
-	chatSpecMap = map[string]string{
+	replSpecMap = map[string]string{
 		"@path":  "Reference to files and folders",
 		"!bash":  "Execute local shell commands",
 		"Ctrl+C": "Cancel current generation or exit session",
@@ -109,8 +109,8 @@ func runCommand(cmd *cobra.Command, args []string) {
 	}
 }
 
-// handleCommand processes chat commands
-func (ci *ChatInfo) handleCommand(cmd string) {
+// handleCommand processes commands
+func (ri *ReplInfo) handleCommand(cmd string) {
 	// Split the command into parts
 	// Robust parsing: find the command (first word) and the raw arguments string
 	cmd = strings.TrimSpace(cmd)
@@ -124,20 +124,20 @@ func (ci *ChatInfo) handleCommand(cmd string) {
 	// To minimize changes, we'll keep 'parts' generally available but also provide robust args parsing where needed.
 	switch command {
 	case "/exit", "/quit":
-		ci.QuitFlag = true
+		ri.QuitFlag = true
 		fmt.Println("Session Ended")
 		return
 
 	case "/help":
-		ci.showHelp()
+		ri.showHelp()
 
 	case "/history":
 		// Arguments (num, chars) are deprecated/ignored in viewport mode
 		// We could implement "--raw" here later
-		ci.showHistory()
+		ri.showHistory()
 
 	case "/clear":
-		ci.clearContext()
+		ri.clearContext()
 
 	case "/model":
 		runCommand(modelCmd, parts[1:])
@@ -169,11 +169,11 @@ func (ci *ChatInfo) handleCommand(cmd string) {
 	case "/yolo":
 		switchYoloMode()
 
-	case "/convo":
+	case "/session":
 		runCommand(convoCmd, parts[1:])
 
 	case "/compress":
-		ci.compressContext()
+		ri.compressContext()
 
 	case "/think":
 		runCommand(thinkCmd, parts[1:])
@@ -183,7 +183,7 @@ func (ci *ChatInfo) handleCommand(cmd string) {
 
 	case "/editor":
 		if len(parts) < 2 {
-			ci.handleEditor()
+			ri.handleEditor()
 			return
 		}
 		runCommand(editorCmd, parts[1:])
@@ -193,20 +193,20 @@ func (ci *ChatInfo) handleCommand(cmd string) {
 			fmt.Println("Please specify a file path")
 			return
 		}
-		ci.attachFiles(cmd)
+		ri.attachFiles(cmd)
 
 	case "/detach":
 		if len(parts) < 2 {
 			fmt.Println("Please specify a file path")
 			return
 		}
-		ci.detachFiles(cmd)
+		ri.detachFiles(cmd)
 
 	case "/copy":
-		ci.copyLastMessage()
+		ri.copyLastMessage()
 
 	case "/about":
-		ci.showInfo()
+		ri.showInfo()
 
 	case "/theme":
 		runCommand(themeCmd, parts[1:])
@@ -219,26 +219,26 @@ func (ci *ChatInfo) handleCommand(cmd string) {
 
 	default:
 		// Try to execute as workflow command
-		if ci.executeWorkflow(command, parts) {
+		if ri.executeWorkflow(command, parts) {
 			return
 		}
 
 		// Try to execute as skill command
-		if ci.executeSkill(command, parts) {
+		if ri.executeSkill(command, parts) {
 			return
 		}
 		fmt.Printf("Unknown command: %s\n", command)
 	}
 }
 
-// showHelp displays available chat commands
-func (ci *ChatInfo) showHelp() {
+// showHelp displays available commands
+func (ri *ReplInfo) showHelp() {
 	// Extract keys into a slice
-	commands := make([]string, 0, len(chatCommandMap)+len(chatSpecMap))
-	for cmd := range chatCommandMap {
+	commands := make([]string, 0, len(replCommandMap)+len(replSpecMap))
+	for cmd := range replCommandMap {
 		commands = append(commands, cmd)
 	}
-	for cmd := range chatSpecMap {
+	for cmd := range replSpecMap {
 		commands = append(commands, cmd)
 	}
 
@@ -271,9 +271,9 @@ func (ci *ChatInfo) showHelp() {
 		paddedText := fmt.Sprintf("%-*s", maxLen, cmd)
 
 		// Get description
-		desc := chatCommandMap[cmd]
+		desc := replCommandMap[cmd]
 		if desc == "" {
-			desc = chatSpecMap[cmd]
+			desc = replSpecMap[cmd]
 		}
 
 		line := fmt.Sprintf("%s   %s", textStyle.Render(paddedText), descStyle.Render(desc))
@@ -284,8 +284,8 @@ func (ci *ChatInfo) showHelp() {
 	fmt.Println(suggestionsView)
 }
 
-// showInfo displays current chat settings and information
-func (ci *ChatInfo) showInfo() {
+// showInfo displays current settings and information
+func (ri *ReplInfo) showInfo() {
 
 	printSection := func(title string) {
 		fmt.Println()
@@ -322,9 +322,9 @@ func (ci *ChatInfo) showInfo() {
 
 	// Attachments
 	printSection("ATTACHMENTS")
-	if len(ci.Files) > 0 {
-		fmt.Printf("%s%s%s (%d):\n", data.KeyColor, "Attachments", data.ResetSeq, len(ci.Files))
-		for _, file := range ci.Files {
+	if len(ri.Files) > 0 {
+		fmt.Printf("%s%s%s (%d):\n", data.KeyColor, "Attachments", data.ResetSeq, len(ri.Files))
+		for _, file := range ri.Files {
 			fmt.Printf("  - [%s]: %s\n", file.Format(), file.Path())
 		}
 	} else {
@@ -334,20 +334,20 @@ func (ci *ChatInfo) showInfo() {
 	fmt.Println()
 }
 
-func (ci *ChatInfo) handleEditor() {
+func (ri *ReplInfo) handleEditor() {
 	// No arguments - check if preferred editor is set
 	if getPreferredEditor() == "" {
 		// No preferred editor set, show list
 		listAvailableEditors()
 	} else {
 		// Preferred editor set, open it
-		ci.handleEditorCommand()
+		ri.handleEditorCommand()
 	}
 }
 
-func (ci *ChatInfo) handleEditorCommand() {
+func (ri *ReplInfo) handleEditorCommand() {
 	editor := getPreferredEditor()
-	tempFile, err := createTempFile(chatEidtTempFile)
+	tempFile, err := createTempFile(editTempFile)
 	if err != nil {
 		service.Errorf("Failed to create temp file: %v", err)
 		return
@@ -381,10 +381,10 @@ func (ci *ChatInfo) handleEditorCommand() {
 	}
 
 	// Set editor input
-	ci.EditorInput = content
+	ri.EditorInput = content
 }
 
-func (ci *ChatInfo) attachFiles(input string) {
+func (ri *ReplInfo) attachFiles(input string) {
 	// Split input into tokens
 	tokens := strings.Fields(input)
 
@@ -420,7 +420,7 @@ func (ci *ChatInfo) attachFiles(input string) {
 					// Check if file is already attached
 					mu.Lock()
 					found := false
-					for _, file := range ci.Files {
+					for _, file := range ri.Files {
 						if file.Path() == filePath {
 							found = true
 							break
@@ -442,7 +442,7 @@ func (ci *ChatInfo) attachFiles(input string) {
 
 					// Append the file to the list of attachments
 					mu.Lock()
-					ci.Files = append(ci.Files, file)
+					ri.Files = append(ri.Files, file)
 					mu.Unlock()
 					fmt.Printf("Attachment loaded: %s\n", filePath)
 				}(filePath)
@@ -454,19 +454,19 @@ func (ci *ChatInfo) attachFiles(input string) {
 	}
 	wg.Wait()
 
-	if len(ci.Files) == 0 {
+	if len(ri.Files) == 0 {
 		fmt.Println("No attachments were loaded")
 	}
 }
 
-func (ci *ChatInfo) detachFiles(input string) {
+func (ri *ReplInfo) detachFiles(input string) {
 	// Handle "all" case
 	if strings.Contains(input, "/detach all") {
-		if len(ci.Files) == 0 {
+		if len(ri.Files) == 0 {
 			fmt.Println("No attachments to detach")
 			return
 		}
-		ci.Files = []*service.FileData{}
+		ri.Files = []*service.FileData{}
 		fmt.Println("Detached all attachments")
 		return
 	}
@@ -490,9 +490,9 @@ func (ci *ChatInfo) detachFiles(input string) {
 
 			// Find and detach the file
 			found := false
-			for j, file := range ci.Files {
+			for j, file := range ri.Files {
 				if file.Path() == filePath {
-					ci.Files = append(ci.Files[:j], ci.Files[j+1:]...)
+					ri.Files = append(ri.Files[:j], ri.Files[j+1:]...)
 					fmt.Printf("Detached: %s\n", filePath)
 					detachedAny = true
 					found = true
@@ -513,7 +513,7 @@ func (ci *ChatInfo) detachFiles(input string) {
 
 // executeWorkflow checks if command is a workflow and executes it
 // Returns true if it was a workflow command
-func (ci *ChatInfo) executeWorkflow(command string, parts []string) bool {
+func (ri *ReplInfo) executeWorkflow(command string, parts []string) bool {
 	// Strip leading /
 	name := strings.TrimPrefix(command, "/")
 
@@ -536,13 +536,13 @@ func (ci *ChatInfo) executeWorkflow(command string, parts []string) bool {
 	}
 
 	// Set the content as input to be processed by the agent
-	ci.EditorInput = input
+	ri.EditorInput = input
 	return true
 }
 
 // executeSkill checks if command is a skill and sets up the prompt to activate it
 // Returns true if it was a skill command
-func (ci *ChatInfo) executeSkill(command string, parts []string) bool {
+func (ri *ReplInfo) executeSkill(command string, parts []string) bool {
 	// Strip leading /
 	name := strings.TrimPrefix(command, "/")
 
@@ -568,7 +568,7 @@ func (ci *ChatInfo) executeSkill(command string, parts []string) bool {
 	}
 
 	// Construct the instruction to force skill activation
-	ci.Instruction = fmt.Sprintf("You need to activate the skill '%s' and follow its instructions to answer the user's request. Use tool 'activate_skill' with the skill name '%s'.", foundSkill.Name, foundSkill.Name)
+	ri.Instruction = fmt.Sprintf("You need to activate the skill '%s' and follow its instructions to answer the user's request. Use tool 'activate_skill' with the skill name '%s'.", foundSkill.Name, foundSkill.Name)
 
 	input := "/" + foundSkill.Name // Fallback to echo the command itself if no args
 	if userArgs != "" {
@@ -576,12 +576,12 @@ func (ci *ChatInfo) executeSkill(command string, parts []string) bool {
 	}
 
 	// Set the content as input to be processed by the agent
-	ci.EditorInput = input
+	ri.EditorInput = input
 	return true
 }
 
 // copyLastMessage copies the last assistant response or its latest code block to the clipboard.
-func (ci *ChatInfo) copyLastMessage() {
+func (ri *ReplInfo) copyLastMessage() {
 	lastAssistantMessage := data.GetClipboardText()
 
 	if lastAssistantMessage == "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ Configure your API keys and preferred models, then start chatting or executing c
 			if len(args) == 0 {
 				// Complete the root command - list all available commands
 				return []string{
-					"agent", "chat", "completion", "config", "convo",
+					"agent", "completion", "config", "session",
 					"diff", "editor", "features", "help", "init",
 					"mcp", "memory", "model", "search", "skills",
 					"system", "template", "theme", "think", "tools", "version",
@@ -100,9 +100,9 @@ Configure your API keys and preferred models, then start chatting or executing c
 				!cmd.Flags().Changed("attachment") &&
 				!cmd.Flags().Changed("version") &&
 				!hasStdinData() {
-				// Default to interactive chat mode when no prompt or subcommand is provided.
+				// Default to interactive REPL mode when no prompt or subcommand is provided.
 				// -g/--agent and -c/--conversation are forwarded via shared package-level globals.
-				if err := chatCmd.RunE(chatCmd, args); err != nil {
+				if err := replCmd.RunE(replCmd, args); err != nil {
 					service.Errorf("%v", err)
 				}
 				return

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -44,7 +44,7 @@ var workflowListCmd = &cobra.Command{
 	Short:   "List all available workflows",
 	Run: func(cmd *cobra.Command, args []string) {
 		wm := service.GetWorkflowManager()
-		if err := wm.LoadMetadata(chatCommandMap); err != nil {
+		if err := wm.LoadMetadata(replCommandMap); err != nil {
 			service.Errorf("Failed to load workflows: %v", err)
 			return
 		}
@@ -74,7 +74,7 @@ var workflowCreateCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		wm := service.GetWorkflowManager()
-		if err := wm.LoadMetadata(chatCommandMap); err != nil {
+		if err := wm.LoadMetadata(replCommandMap); err != nil {
 			service.Errorf("Failed to load workflows: %v", err)
 			return
 		}
@@ -160,7 +160,7 @@ var workflowRemoveCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		wm := service.GetWorkflowManager()
-		if err := wm.LoadMetadata(chatCommandMap); err != nil {
+		if err := wm.LoadMetadata(replCommandMap); err != nil {
 			service.Errorf("Failed to load workflows: %v", err)
 			return
 		}
@@ -222,7 +222,7 @@ var workflowRenameCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		wm := service.GetWorkflowManager()
-		if err := wm.LoadMetadata(chatCommandMap); err != nil {
+		if err := wm.LoadMetadata(replCommandMap); err != nil {
 			service.Errorf("Failed to load workflows: %v", err)
 			return
 		}
@@ -299,7 +299,7 @@ var workflowInfoCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		wm := service.GetWorkflowManager()
-		if err := wm.LoadMetadata(chatCommandMap); err != nil {
+		if err := wm.LoadMetadata(replCommandMap); err != nil {
 			service.Errorf("Failed to load workflows: %v", err)
 			return
 		}
@@ -352,7 +352,7 @@ var workflowSetCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		wm := service.GetWorkflowManager()
-		if err := wm.LoadMetadata(chatCommandMap); err != nil {
+		if err := wm.LoadMetadata(replCommandMap); err != nil {
 			service.Errorf("Failed to load workflows: %v", err)
 			return
 		}


### PR DESCRIPTION
### Feature Improvements: Default Chat Mode and REPL Refactor

This PR brings significant UX improvements to how users interact with `gllm`.

#### Key Changes:
1.  **Implicit Chat Mode**: Running `gllm` without any arguments or subcommands now defaults directly into an interactive session.
2.  **Subcommand Rename**: The technical `chat` subcommand has been renamed to `repl` to better reflect its technical nature, and it has been hidden from the main help menu to keep the CLI interface clean.
3.  **Terminology Update**: Standardized "chat" terminology to "session" or "repl" throughout the command-line interface and internal code structures for consistency.
4.  **Flag Forwarding**: Properly forwarded global flags like `--agent (-g)` and `--conversation (-c)` when launching the default interactive mode.
5.  **Clipboard Optimization**: (From previous commit) Enhanced `/copy` command to capture rendered markdown directly without extra disk I/O.

#### Technical Details:
- Files renamed: `cmd/chat.go` -> `cmd/repl.go`, `cmd/chatcmds.go` -> `cmd/replcmds.go`.
- Structs renamed: `ChatInfo` -> `ReplInfo`.
- Globals renamed: `chatCommandMap` -> `replCommandMap`.

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * REPL mode now automatically activates when the application is started without arguments or input data.

* **Refactor**
  * Renamed "chat" command to "repl".
  * Renamed "convo" command to "session".
  * Updated help text, command descriptions, and user-facing messages throughout the application to reflect the new command terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->