### PR TITLE
refactor: implement Mediator pattern and unified session mode cycling

### DIFF
--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -13,7 +13,6 @@ import (
 	"github.com/activebook/gllm/internal/ui"
 	"github.com/activebook/gllm/service"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/huh"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
@@ -165,26 +164,6 @@ func (ri *ReplInfo) printWelcome() {
 	fmt.Println()
 }
 
-// This is the legacy awaitChat function, which uses huh, don't support auto-complete
-func (ri *ReplInfo) awaitChat_legacy() (string, error) {
-	var input string
-
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewText().
-				Title("Chat").
-				Value(&input).
-				Placeholder("Type your message..."),
-		),
-	).WithKeyMap(ui.GetHuhKeyMap()) // 4. CRITICAL: Apply the keymap to the FORM level
-
-	err := form.Run()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(input), nil
-}
-
 // This is the new awaitInput function, which uses bubbletea, support auto-complete
 func (ri *ReplInfo) awaitInput() (string, error) {
 	agent, err := EnsureActiveAgent()
@@ -243,9 +222,12 @@ func (ri *ReplInfo) awaitInput() (string, error) {
 		IsPlanModeActive: func() bool {
 			return data.IsPlanModeInSessionEnabled() && data.GetPlanModeInSession()
 		},
-		TogglePlanMode: func() {
-			// The /plan command in the REPL should only be available if the "Plan Mode" feature is enabled for the current agent.
-			switchPlanMode(nil)
+		IsYoloModeActive: func() bool {
+			return data.GetYoloModeInSession()
+		},
+		ToggleSessionMode: func() {
+			// here we do a cycle [normal->plan->yolo->normal]
+			switchSessionMode()
 		},
 	}
 
@@ -271,7 +253,7 @@ func (ri *ReplInfo) startREPL() {
 	defer ri.sharedState.Clear()
 
 	// Set auto approve for the session
-	data.SetToolCallAutoApproveInSession(yoloFlag)
+	data.SetYoloModeInSession(yoloFlag)
 
 	// Start the REPL
 	ri.printWelcome()

--- a/cmd/replcmds.go
+++ b/cmd/replcmds.go
@@ -22,7 +22,8 @@ var (
 		"/help":     "Show this help message",
 		"/history":  "Show recent session history",
 		"/clear":    "Clear session history",
-		"/plan":     "Toggle Plan Mode (shift+tab)",
+		"/plan":     "Toggle Plan Mode (shift+tab to cycle)",
+		"/yolo":     "Toggle YOLO mode (shift+tab to cycle)",
 		"/model":    "Manage models (list, switch, add, etc.)",
 		"/agent":    "Manage agents (list, switch, add, etc.)",
 		"/template": "Manage templates (list, switch, add, etc.)",
@@ -32,7 +33,6 @@ var (
 		"/mcp":      "Manage MCP servers (list, switch, etc.)",
 		"/skills":   "Manage agent skills (list, switch, install, etc.)",
 		"/memory":   "Manage memory (list, add, clear)",
-		"/yolo":     "Toggle YOLO mode",
 		"/session":  "Manage sessions (list, info, remove, etc.)",
 		"/compress": "Compresses the context by replacing it with a summary",
 		"/think":    "Set thinking level",
@@ -51,9 +51,9 @@ var (
 	replSpecMap = map[string]string{
 		"@path":     "Reference to files and folders",
 		"!bash":     "Execute local shell commands",
-		"shift+tab": "Toggle plan mode",
+		"shift+tab": "Toggle plan mode or yolo mode",
 		"ctrl+c":    "Cancel current generation or exit session",
-		"ctrl+d":    "Delete all input",
+		"ctrl+d":    "Clear all input",
 	}
 )
 
@@ -65,45 +65,6 @@ func contains(slice []string, item string) bool {
 		}
 	}
 	return false
-}
-
-// switchYoloMode toggles YOLO mode
-func switchYoloMode() {
-	yolo := data.GetToolCallAutoApproveInSession()
-	if yolo {
-		fmt.Printf("YOLO mode: %s -> %s\n", data.SwitchOnColor+"on"+data.ResetSeq, data.SwitchOffColor+"off"+data.ResetSeq)
-		data.SetToolCallAutoApproveInSession(false)
-	} else {
-		fmt.Printf("YOLO mode: %s -> %s\n", data.SwitchOffColor+"off"+data.ResetSeq, data.SwitchOnColor+"on"+data.ResetSeq)
-		data.SetToolCallAutoApproveInSession(true)
-	}
-}
-
-func showPlanModeStatus() {
-	plan := data.GetPlanModeInSession()
-	if plan {
-		fmt.Printf("Plan mode: %s -> %s\n", data.SwitchOnColor+"on"+data.ResetSeq, data.SwitchOffColor+"off"+data.ResetSeq)
-	} else {
-		fmt.Printf("Plan mode: %s -> %s\n", data.SwitchOffColor+"off"+data.ResetSeq, data.SwitchOnColor+"on"+data.ResetSeq)
-	}
-}
-
-// switchPlanMode toggles Plan mode
-func switchPlanMode(showStatus func()) {
-	// The /plan command in the REPL should only be available if the "Plan Mode" feature is enabled for the current agent.
-	if !data.IsPlanModeInSessionEnabled() {
-		service.Warnln("Please enable Plan Mode feature first.")
-		return
-	}
-
-	plan := data.GetPlanModeInSession()
-	data.SetPlanModeInSession(!plan)
-	// SendEvent is a best-effort signal; it's a no-op if RunChatInput isn't active,
-	// but the next NewChatInputModel call will read the updated session state anyway.
-	ui.SendEvent(ui.PlanModeMsg{Active: !plan})
-	if showStatus != nil {
-		showStatus()
-	}
 }
 
 // runCommand executes a command with arguments
@@ -198,7 +159,7 @@ func (ri *ReplInfo) handleCommand(cmd string) {
 		runCommand(memoryCmd, parts[1:])
 
 	case "/yolo":
-		switchYoloMode()
+		switchYoloMode(showYoloModeStatus)
 
 	case "/plan":
 		switchPlanMode(showPlanModeStatus)
@@ -615,4 +576,118 @@ func (ri *ReplInfo) executeSkill(command string, parts []string) bool {
 	// Set the content as input to be processed by the agent
 	ri.EditorInput = input
 	return true
+}
+
+/**
+ * This part is session mode switching
+ * [normal -> plan -> yolo -> normal]
+ * /plan -> switch to plan mode
+ * /yolo -> switch to yolo mode
+ * /plan and /yolo is exclusive, if both are enabled, it will switch to normal mode
+ */
+
+func showPlanModeStatus(plan bool) {
+	if plan {
+		fmt.Printf("Plan mode: %s -> %s\n", data.SwitchOffColor+"off"+data.ResetSeq, data.SwitchOnColor+"on"+data.ResetSeq)
+	} else {
+		fmt.Printf("Plan mode: %s -> %s\n", data.SwitchOnColor+"on"+data.ResetSeq, data.SwitchOffColor+"off"+data.ResetSeq)
+	}
+}
+
+func showYoloModeStatus(yolo bool) {
+	if yolo {
+		fmt.Printf("YOLO mode: %s -> %s\n", data.SwitchOffColor+"off"+data.ResetSeq, data.SwitchOnColor+"on"+data.ResetSeq)
+	} else {
+		fmt.Printf("YOLO mode: %s -> %s\n", data.SwitchOnColor+"on"+data.ResetSeq, data.SwitchOffColor+"off"+data.ResetSeq)
+	}
+}
+
+// switchYoloMode toggles YOLO mode
+func switchYoloMode(showStatus func(bool)) {
+	yolo := data.GetYoloModeInSession()
+	// Switch yolo mode
+	data.SetYoloModeInSession(!yolo)
+	// Always turn off plan mode
+	data.SetPlanModeInSession(false)
+	yolo = data.GetYoloModeInSession()
+	// SendEvent is a best-effort signal; it's a no-op if RunChatInput isn't active,
+	// but the next NewChatInputModel call will read the updated session state anyway.
+	if yolo {
+		ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModeYolo})
+	} else {
+		ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModeNormal})
+	}
+	if showStatus != nil {
+		showStatus(yolo)
+	}
+}
+
+// switchPlanMode toggles Plan mode
+func switchPlanMode(showStatus func(bool)) {
+	// The /plan command in the REPL should only be available if the "Plan Mode" feature is enabled for the current agent.
+	if !data.IsPlanModeInSessionEnabled() {
+		service.Warnln("Please enable Plan Mode feature first.")
+		return
+	}
+
+	plan := data.GetPlanModeInSession()
+	// Switch plan mode
+	data.SetPlanModeInSession(!plan)
+	// Always turn off yolo mode
+	data.SetYoloModeInSession(false)
+	plan = data.GetPlanModeInSession()
+	// SendEvent is a best-effort signal; it's a no-op if RunChatInput isn't active,
+	// but the next NewChatInputModel call will read the updated session state anyway.
+	if plan {
+		ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModePlan})
+	} else {
+		ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModeNormal})
+	}
+	if showStatus != nil {
+		showStatus(plan)
+	}
+}
+
+/**
+ * Switches the session mode to the next mode in the cycle [normal->plan->yolo->normal].
+ * If plan mode is enabled, it will switch to plan mode.
+ * If plan mode is disabled, it will switch to yolo mode.
+ * If both plan and yolo modes are enabled, it will switch to normal mode.
+ * If both plan and yolo modes are disabled, it will switch to normal mode.
+ */
+func switchSessionMode() {
+	// here we do a cycle [normal->plan->yolo->normal]
+	planModeInSession, yoloModeInSession := data.GetSessionMode()
+	planEnabled := data.IsPlanModeInSessionEnabled()
+
+	if !planModeInSession && !yoloModeInSession {
+		if planEnabled {
+			// normal -> plan
+			data.SetPlanModeInSession(true)
+			data.SetYoloModeInSession(false)
+			ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModePlan})
+		} else {
+			// plan disabled, skip to yolo
+			// normal -> yolo
+			data.SetPlanModeInSession(false)
+			data.SetYoloModeInSession(true)
+			ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModeYolo})
+		}
+	} else if planModeInSession && !yoloModeInSession {
+		// plan -> yolo
+		data.SetPlanModeInSession(false)
+		data.SetYoloModeInSession(true)
+		ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModeYolo})
+	} else if !planModeInSession && yoloModeInSession {
+		// yolo -> normal
+		data.SetPlanModeInSession(false)
+		data.SetYoloModeInSession(false)
+		ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModeNormal})
+	} else {
+		// back to normal
+		service.Warnf("Plan mode and yolo mode shouldn't be both turned on.")
+		data.SetPlanModeInSession(false)
+		data.SetYoloModeInSession(false)
+		ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModeNormal})
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,7 +127,7 @@ Configure your API keys and preferred models, then start chatting or executing c
 			ui.GetIndicator().Start("")
 
 			// Set auto approve for the session
-			data.SetToolCallAutoApproveInSession(yoloFlag)
+			data.SetYoloModeInSession(yoloFlag)
 
 			// If session flag is provided, find the session file
 			if cmd.Flags().Changed("session") {

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -55,7 +55,7 @@ func RunAgent(prompt string, files []*service.FileData, sessionName string, outp
 		ui.GetIndicator().Start("")
 
 		// Get YOLO mode
-		yolo := data.GetToolCallAutoApproveInSession()
+		yolo := data.GetYoloModeInSession()
 
 		// Ensure Active Agent
 		agent, err := EnsureActiveAgent()

--- a/data/session.go
+++ b/data/session.go
@@ -186,6 +186,7 @@ var (
 	// Agents and Subagents all share this mode
 	planModeInSession        = false
 	planModeInSessionEnabled = false
+	yoloModeInSession        = false
 )
 
 const (
@@ -211,10 +212,39 @@ func GetPlanModeInSession() bool {
 	return planModeInSession
 }
 
+/**
+ * Enable plan mode in session
+ */
 func EnablePlanModeInSession(enable bool) {
 	planModeInSessionEnabled = enable
 }
 
+/**
+ * Check if plan mode is enabled in session
+ */
 func IsPlanModeInSessionEnabled() bool {
 	return planModeInSessionEnabled
+}
+
+/**
+ * Set YOLO mode(tool calls auto approve) in session
+ */
+func SetYoloModeInSession(value bool) {
+	yoloModeInSession = value
+}
+
+/**
+ * Get YOLO mode in session
+ */
+func GetYoloModeInSession() bool {
+	return yoloModeInSession
+}
+
+/**
+ * Get session mode
+ *
+ * @return planModeInSession, yoloModeInSession
+ */
+func GetSessionMode() (bool, bool) {
+	return planModeInSession, yoloModeInSession
 }

--- a/data/theme.go
+++ b/data/theme.go
@@ -105,6 +105,7 @@ var (
 	UpdateAvailableHex string
 
 	PlanModeHex string
+	YoloModeHex string
 
 	// Functional Helpers (for backwards compatibility or convenience)
 	// These might wrap the strings above
@@ -249,6 +250,7 @@ func applyTheme(t goghthemes.Theme) {
 	UpdateAvailableHex = t.Yellow
 
 	PlanModeHex = t.BrightMagenta
+	YoloModeHex = t.BrightRed
 }
 
 // ListThemes returns a sorted list of all available theme names.

--- a/data/tools.go
+++ b/data/tools.go
@@ -26,22 +26,3 @@ func (tu *ToolsUse) ConfirmCancel() {
 	tu.Confirm = ToolConfirmCancel
 	tu.AutoApprove = false
 }
-
-var (
-	// Whether tools can be used without user confirmation in the current session
-	toolCallAutoApproveInSession = false
-)
-
-/**
- * Set tool call auto approve in session
- */
-func SetToolCallAutoApproveInSession(value bool) {
-	toolCallAutoApproveInSession = value
-}
-
-/**
- * Get tool call auto approve in session
- */
-func GetToolCallAutoApproveInSession() bool {
-	return toolCallAutoApproveInSession
-}

--- a/internal/ui/chatinput.go
+++ b/internal/ui/chatinput.go
@@ -27,14 +27,35 @@ const (
 
 var (
 	planModeBanner string       // plan mode banner
+	yoloModeBanner string       // yolo mode banner
 	activeProgram  *tea.Program // reference to the running program for external Send()
 )
+
+type SessionMode int
+
+const (
+	SessionModeNormal = iota
+	SessionModePlan
+	SessionModeYolo
+)
+
+// ChatInputHooks allows an external orchestrator to provide state and handle events
+type ChatInputHooks struct {
+	// IsPlanModeActive returns true if in plan mode
+	IsPlanModeActive func() bool
+
+	// IsYoloModeActive returns true if in yolo mode
+	IsYoloModeActive func() bool
+
+	// ToggleSessionMode toggles the session mode
+	ToggleSessionMode func()
+}
 
 // BannerMsg carries a notification banner text to display above the input.
 type BannerMsg struct{ Text string }
 
-// PlanModeMsg signals a Plan Mode toggle to the UI.
-type PlanModeMsg struct{ Active bool }
+// SessionModeMsg signals a session mode toggle to the UI.
+type SessionModeMsg struct{ Mode SessionMode }
 
 // SendEvent dispatches a message to the active chat input program.
 // Goroutine-safe; no-op when no program is running.
@@ -57,15 +78,6 @@ type ChatInputResult struct {
 type Suggestion struct {
 	Command     string
 	Description string
-}
-
-// ChatInputHooks allows an external orchestrator to provide state and handle events
-type ChatInputHooks struct {
-	// IsPlanModeActive returns true if in plan mode
-	IsPlanModeActive func() bool
-
-	// TogglePlanMode toggles the plan mode
-	TogglePlanMode func()
 }
 
 // ChatInputModel is the Bubble Tea model for the chat input with autocomplete
@@ -119,18 +131,25 @@ func NewChatInputModel(commands []Suggestion, initialValue string, history []str
 		ta.SetCursor(len(initialValue))
 	}
 
-	// Initialize banner if plan mode is active
+	// Initialize banner if plan/yolo mode is active
 	planModeStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(data.PlanModeHex)).
 		Bold(true)
+	yoloModeStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(data.YoloModeHex)).
+		Bold(true)
 	planModeBanner = planModeStyle.Render("plan mode")
-	infoBanner := ""
+	yoloModeBanner = yoloModeStyle.Render("yolo mode")
 
+	infoBanner := ""
 	// Check if plan mode is enabled
-	if hooks.IsPlanModeActive != nil {
-		if hooks.IsPlanModeActive() {
-			infoBanner = planModeBanner
-		}
+	switch {
+	case hooks.IsPlanModeActive != nil && hooks.IsPlanModeActive():
+		infoBanner = planModeBanner
+	case hooks.IsYoloModeActive != nil && hooks.IsYoloModeActive():
+		infoBanner = yoloModeBanner
+	default:
+		infoBanner = ""
 	}
 
 	width := GetTerminalWidth()
@@ -318,10 +337,13 @@ func (m ChatInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pendingBanner = msg.Text
 		return m, nil
 
-	case PlanModeMsg:
-		if msg.Active {
+	case SessionModeMsg:
+		switch msg.Mode {
+		case SessionModePlan:
 			m.infoBanner = planModeBanner
-		} else {
+		case SessionModeYolo:
+			m.infoBanner = yoloModeBanner
+		case SessionModeNormal:
 			m.infoBanner = ""
 		}
 		return m, nil
@@ -373,8 +395,8 @@ func (m ChatInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case tea.KeyShiftTab:
-			if m.hooks.TogglePlanMode != nil {
-				m.hooks.TogglePlanMode()
+			if m.hooks.ToggleSessionMode != nil {
+				m.hooks.ToggleSessionMode()
 				return m, nil
 			}
 

--- a/internal/ui/readline.go
+++ b/internal/ui/readline.go
@@ -112,7 +112,13 @@ func NeedUserConfirmToolUse(info string, prompt string, description string, tool
 	switch choice {
 	case "All":
 		toolsUse.ConfirmAlways()
-		data.SetToolCallAutoApproveInSession(true)
+		// If user choose "All", it means user want to use tools without confirmation in this session
+		// So we need to set yolo mode in session
+		planModeInSession, yoloModeInSession := data.GetSessionMode()
+		// If user is in plan mode, don't set yolo mode
+		if !planModeInSession && !yoloModeInSession {
+			data.SetYoloModeInSession(true)
+		}
 	case "Yes":
 		toolsUse.ConfirmOnce()
 	default:

--- a/service/tools_impl.go
+++ b/service/tools_impl.go
@@ -1511,7 +1511,7 @@ func exitPlanModeToolCallImpl(argsMap *map[string]interface{}, toolsUse *data.To
 	// read the updated state and hide the banner automatically.
 	data.SetPlanModeInSession(false)
 	// Best-effort: if RunChatInput somehow is running concurrently, update banner.
-	ui.SendEvent(ui.PlanModeMsg{Active: false})
+	ui.SendEvent(ui.SessionModeMsg{Mode: ui.SessionModeNormal})
 
 	return "Successfully exited Plan Mode. Current session is now in normal execution mode.", nil
 }


### PR DESCRIPTION
### Description

This PR implements a robust **Mediator Pattern** to decouple the TUI layer from the Command and Data layers, resolving systemic coupling issues identified in #123.

### Key Changes

1.  **Mediator Pattern Implementation**:
    *   Introduced `ChatInputHooks` in `internal/ui` to abstract state transitions.
    *   Injected functional callbacks from `cmd/repl` into the UI, keeping the UI "dumb" and agnostic to the underlying data package.
2.  **Unified Session Mode Cycling**:
    *   Consolidated Plan Mode and YOLO Mode into a single cycle: `Normal -> Plan -> YOLO -> Normal`.
    *   Implemented this cycle via `Shift+Tab` in the chat input.
    *   Enforced mutual exclusivity between modes (turning on one clears the other).
3.  **Capability-Aware Logic**:
    *   The session cycle now respects agent capabilities. If **Plan Mode** is disabled for the current agent, the cycle automatically skips from Normal to YOLO.
4.  **Asynchronous TUI Bridge**:
    *   Refactored `ui.SendEvent` to be goroutine-safe and asynchronous, preventing REPL deadlocks when the UI message loop is saturated.

### Closing Information
Closes #123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added YOLO mode as a toggleable session mode alongside Plan Mode
  * Session modes now cycle through states with visual banners indicating the active mode
  * New `/yolo` and `/plan` commands in REPL for easy mode toggling
  * Status feedback displayed when switching between session modes
  
* **Refactor**
  * Improved session mode management and visual state handling
  * Tool confirmation workflow now intelligently manages session modes when approving all tool calls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->