### PR TITLE
Merge develop into main - 2026-03-22

### DIFF
--- a/service/tools_common.go
+++ b/service/tools_common.go
@@ -1324,6 +1324,11 @@ Capability details (CRITICAL: Do NOT place these tools in the 'tools' field. Ena
 					"type":        "string",
 					"description": "Full persona and behavioural instructions for this agent. Be comprehensive — this is the only instruction source.",
 				},
+				"need_confirm": map[string]interface{}{
+					"type":        "boolean",
+					"description": "Whether to prompt the user for confirmation before building agents. Defaults to true.",
+					"default":     true,
+				},
 			},
 			"required": []string{"name", "description", "tools", "capabilities", "think", "system_prompt"},
 		},

--- a/service/tools_impl.go
+++ b/service/tools_impl.go
@@ -1380,7 +1380,12 @@ func buildAgentToolCallImpl(argsMap *map[string]interface{}, toolsUse *data.Tool
 	}
 
 	// ── Confirm before writing ───────────────────────────────────────────────
-	if !toolsUse.AutoApprove {
+	// Check for confirmation
+	needConfirm, ok := (*argsMap)["need_confirm"].(bool)
+	if !ok {
+		needConfirm = true // Default to true
+	}
+	if needConfirm && !toolsUse.AutoApprove {
 		purpose := fmt.Sprintf("build agent '%s' with %d tools and %d capabilities", name, len(selectedTools), len(selectedCaps))
 		event.RequestConfirm(purpose, toolsUse)
 		if toolsUse.Confirm == data.ToolConfirmCancel {


### PR DESCRIPTION
## 🚀 Deployment PR

This PR merges the latest changes from `develop` into `main`.

### 📊 Summary
- **Commits**: 1
- **Base**: `main`
- **Head**: `develop`

### 📝 Recent Changes
- 65b061c feat: Add `need_confirm` parameter to `build_agent` tool to control confirmation prompt before agent creation.

### ✅ Checklist
- All tests pass
- Code has been reviewed
- Documentation is updated (if needed)
- Ready for production deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Agent creation now supports optional confirmation control, allowing users to configure whether confirmation is required before building agents. This enables streamlined automation while maintaining secure defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->