### PR TITLE
Merge develop into main - 2026-03-30

### DIFF
--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -144,14 +144,13 @@ func RunAgent(prompt string, files []*service.FileData, sessionName string, outp
 	return nil
 }
 
-// buildFinalPrompt combines user input, injects VSCode context, and processes @ references
+// buildFinalPrompt combines user input, injects registered context providers, and processes @ references
 func buildFinalPrompt(input string) string {
 	tb := TextBuilder{}
 
-	// Inject VSCode Context before user input if available
-	vscodeCtx := service.GetVSCodeContextString()
-	if vscodeCtx != "" {
-		tb.appendText(vscodeCtx)
+	// Collect context from all registered providers (e.g. VSCode Companion, future plugins)
+	if ctx := service.NewContextHooks().Collect(); ctx != "" {
+		tb.appendText(ctx)
 		tb.appendText("\n---\n\n")
 	}
 

--- a/service/hooks.go
+++ b/service/hooks.go
@@ -1,5 +1,7 @@
 package service
 
+import "strings"
+
 // FileHooks holds registered callbacks for file lifecycle events.
 // All hook funcs are invoked asynchronously by their caller.
 type FileHooks struct {
@@ -38,4 +40,34 @@ func (h *FileHooks) Discard(path string) {
 	for _, fn := range h.OnDiscard {
 		fn(path)
 	}
+}
+
+// ContextHooks holds registered providers that contribute additional context
+// to the LLM prompt at the start of every user turn.
+// Each provider is a func() string that returns a formatted context block,
+// or an empty string if it has nothing to contribute (e.g. plugin disabled).
+type ContextHooks struct {
+	providers []func() string
+}
+
+// NewContextHooks builds a ContextHooks populated from all currently-enabled context providers.
+func NewContextHooks() ContextHooks {
+	var h ContextHooks
+	// VSCode Companion plugin: injects active file, cursor, and selected text
+	h.providers = append(h.providers, GetVSCodeContext)
+	// Future context providers: append more funcs here
+	// e.g. h.providers = append(h.providers, GetGitContextString)
+	return h
+}
+
+// Collect calls all registered providers synchronously and returns the joined
+// non-empty contributions, ready for prepending to the LLM prompt.
+func (h ContextHooks) Collect() string {
+	var parts []string
+	for _, fn := range h.providers {
+		if s := fn(); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, "\n")
 }

--- a/service/plugin_companion.go
+++ b/service/plugin_companion.go
@@ -149,8 +149,8 @@ type EditorOpenFile struct {
 	IsDirty  bool   `json:"isDirty"`
 }
 
-// fetchVSCodeContext fetches real-time state from the VSCode companion plugin synchronously.
-func fetchVSCodeContext() (*EditorContext, error) {
+// fetchVSCodeCurrentContext fetches real-time state from the VSCode companion plugin synchronously.
+func fetchVSCodeCurrentContext() (*EditorContext, error) {
 	network, addr := companionSocket()
 	conn, err := net.DialTimeout(network, addr, 500*time.Millisecond)
 	if err != nil {
@@ -185,14 +185,14 @@ func fetchVSCodeContext() (*EditorContext, error) {
 	return &ctx, nil
 }
 
-// GetVSCodeContextString formats the current VSCode state into a JSON block suitable for LLM injection.
-func GetVSCodeContextString() string {
+// GetVSCodeContext formats the current VSCode state into a JSON block suitable for LLM injection.
+func GetVSCodeContext() string {
 	if !data.GetSettingsStore().IsPluginEnabled(PluginVSCodeCompanion) {
 		return ""
 	}
 
 	// We unmarshal to validate structure and filter out omitted fields
-	ctx, err := fetchVSCodeContext()
+	ctx, err := fetchVSCodeCurrentContext()
 	if err != nil || ctx == nil {
 		return "" // Silently fallback if VSCode is not running or error
 	}


### PR DESCRIPTION
## 🚀 Deployment PR

This PR merges the latest changes from `develop` into `main`.

### 📊 Summary
- **Commits**: 3
- **Base**: `main`
- **Head**: `develop`

### 🔗 Linked Issues
Closes #179

### 📝 Recent Changes
- 46caca9 refactor: implement extensible context provider hooks to replace hardcoded VSCode context injection
- 6cb1441 refactor: simplify VSCode context serialization by switching from XML to JSON output and privatizing fetcher function
- 3f23abc feat: inject VSCode editor context into prompt generation via companion plugin

### ✅ Checklist
- All tests pass
- Code has been reviewed
- Documentation is updated (if needed)
- Ready for production deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic injection of VS Code editor context into prompts, enabling the AI to be fully aware of your active file, programming language, text selections, cursor position, and the complete list of all open files when the companion plugin is enabled. Context is seamlessly collected and prepended to all prompt processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->