### PR TITLE
Fix: bufio.Scanner Token Too Long on Image-Heavy Sessions (Issue #204)

### DIFF
--- a/data/memory.go
+++ b/data/memory.go
@@ -3,6 +3,7 @@ package data
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,27 +45,28 @@ func (m *MemoryStore) Load() ([]string, error) {
 	defer file.Close()
 
 	var memories []string
-	scanner := bufio.NewScanner(file)
+	reader := bufio.NewReader(file)
 	inMemorySection := false
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	for {
+		lineBytes, err := reader.ReadBytes('\n')
+		line := strings.TrimRight(string(lineBytes), "\r\n")
 
 		if strings.TrimSpace(line) == MemoryHeader {
 			inMemorySection = true
-			continue
-		}
-
-		if inMemorySection && strings.HasPrefix(strings.TrimSpace(line), "- ") {
+		} else if inMemorySection && strings.HasPrefix(strings.TrimSpace(line), "- ") {
 			memory := strings.TrimPrefix(strings.TrimSpace(line), "- ")
 			if memory != "" {
 				memories = append(memories, memory)
 			}
 		}
-	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading memory file: %w", err)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error reading memory file: %w", err)
+		}
 	}
 
 	return memories, nil

--- a/service/serializer.go
+++ b/service/serializer.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -264,8 +265,9 @@ func DetectMessageProviderByContent(input []byte) string {
 	return ModelProviderUnknown
 }
 
-// Detects the session provider based on message format using a scanner
-// This is more efficient for large files as it doesn't read the entire file into memory
+// DetectMessageProvider detects the session provider by scanning the JSONL file.
+// Uses bufio.Reader to handle arbitrarily long lines (e.g. base64-encoded images)
+// without hitting bufio.Scanner's fixed token-size ceiling.
 func DetectMessageProvider(path string) string {
 	file, err := os.Open(path)
 	if err != nil {
@@ -273,29 +275,34 @@ func DetectMessageProvider(path string) string {
 	}
 	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
-	// Increase buffer size for long messages
-	buf := make([]byte, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
-
+	reader := bufio.NewReaderSize(file, 64*1024)
 	var weakMatch bool
 
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		provider := DetectMessageProviderFromLine(line)
+	for {
+		line, err := reader.ReadBytes('\n')
+		line = bytes.TrimSpace(line)
 
-		if provider != ModelProviderUnknown && provider != ModelProviderOpenAICompatible {
-			return provider // Found definitive match
+		if len(line) > 0 {
+			provider := DetectMessageProviderFromLine(line)
+			if provider != ModelProviderUnknown && provider != ModelProviderOpenAICompatible {
+				return provider
+			}
+			if provider == ModelProviderOpenAICompatible {
+				weakMatch = true
+			}
 		}
-		if provider == ModelProviderOpenAICompatible {
-			weakMatch = true
+
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return ModelProviderUnknown
 		}
 	}
 
 	if weakMatch {
 		return ModelProviderOpenAICompatible
 	}
-
 	return ModelProviderUnknown
 }
 

--- a/service/session_common.go
+++ b/service/session_common.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,6 +74,10 @@ func (s *BaseSession) GetTopSessionName() string {
 
 // readFile reads the JSONL file and returns each line as a separate byte slice.
 // Each line in a JSONL file is a complete JSON object representing one message.
+//
+// Uses bufio.Reader.ReadBytes instead of bufio.Scanner so that lines of
+// arbitrary length (e.g. base64-encoded images) are handled without hitting
+// the scanner's fixed token-size ceiling.
 func (s *BaseSession) readFile() ([][]byte, error) {
 	if s.Name == "" {
 		return nil, nil
@@ -87,27 +92,29 @@ func (s *BaseSession) readFile() ([][]byte, error) {
 	}
 	defer file.Close()
 
+	// 64 KB I/O read buffer — controls disk read granularity, NOT max line size.
+	reader := bufio.NewReaderSize(file, 64*1024)
 	var lines [][]byte
-	scanner := bufio.NewScanner(file)
-	buf := make([]byte, 64*1024)   // Start with 64KB
-	scanner.Buffer(buf, 1024*1024) // Can grow up to 1MB
 
-	for scanner.Scan() {
-		line := bytes.TrimSpace(scanner.Bytes())
-		if len(line) == 0 {
-			continue // Skip empty lines
-		}
-		if !json.Valid(line) {
-			return nil, fmt.Errorf("invalid JSON in session file '%s'", s.Path)
-		}
-		// Make a copy since scanner reuses the buffer
-		lineCopy := make([]byte, len(line))
-		copy(lineCopy, line)
-		lines = append(lines, lineCopy)
-	}
+	for {
+		// ReadBytes reads until '\n' regardless of how large the line is.
+		// It always returns a fresh allocation, so no copy is needed.
+		line, err := reader.ReadBytes('\n')
+		line = bytes.TrimSpace(line)
 
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading session file '%s': %w", s.Path, err)
+		if len(line) > 0 {
+			if !json.Valid(line) {
+				return nil, fmt.Errorf("invalid JSON in session file '%s'", s.Path)
+			}
+			lines = append(lines, line)
+		}
+
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error reading session file '%s': %w", s.Path, err)
+		}
 	}
 
 	return lines, nil

--- a/service/session_common_test.go
+++ b/service/session_common_test.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestReadFileWithLargeImageLine verifies that readFile can handle JSONL session
+// files where a single line exceeds 1 MB (e.g., a base64-encoded image payload).
+// This is a regression test for the "bufio.Scanner: token too long" crash that
+// occurred when loading sessions created from image-bearing turns.
+func TestReadFileWithLargeImageLine(t *testing.T) {
+	t.Parallel()
+
+	// Build a synthetic Gemini content message with a large inline-data blob.
+	// The base64 string is 2 MB, which is well beyond bufio.MaxScanTokenSize (64 KB)
+	// and the previously configured 1 MB ceiling.
+	largeBase64 := strings.Repeat("A", 2*1024*1024) // 2 MB of 'A's
+
+	type inlineData struct {
+		MIMEType string `json:"mimeType"`
+		Data     string `json:"data"`
+	}
+	type part struct {
+		InlineData *inlineData `json:"inlineData,omitempty"`
+		Text       string      `json:"text,omitempty"`
+	}
+	type geminiContent struct {
+		Role  string `json:"role"`
+		Parts []part `json:"parts"`
+	}
+
+	messages := []geminiContent{
+		{
+			Role: "user",
+			Parts: []part{
+				{InlineData: &inlineData{MIMEType: "image/png", Data: largeBase64}},
+				{Text: "describe this image"},
+			},
+		},
+		{
+			Role:  "model",
+			Parts: []part{{Text: "It looks like a large test image."}},
+		},
+	}
+
+	// Write messages as JSONL to a temp file.
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, "sessions", "test-session")
+	if err := os.MkdirAll(sessionDir, 0750); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+	sessionFile := filepath.Join(sessionDir, "main.jsonl")
+
+	f, err := os.Create(sessionFile)
+	if err != nil {
+		t.Fatalf("failed to create session file: %v", err)
+	}
+	enc := json.NewEncoder(f)
+	for _, msg := range messages {
+		if err := enc.Encode(msg); err != nil {
+			f.Close()
+			t.Fatalf("failed to encode message: %v", err)
+		}
+	}
+	f.Close()
+
+	// Use BaseSession directly to invoke readFile.
+	session := &BaseSession{
+		Name: "test-session",
+		Path: sessionFile,
+	}
+
+	lines, err := session.readFile()
+	if err != nil {
+		t.Fatalf("readFile() returned error for large image line: %v", err)
+	}
+
+	if got, want := len(lines), len(messages); got != want {
+		t.Errorf("readFile() returned %d lines, want %d", got, want)
+	}
+}

--- a/service/tools_impl.go
+++ b/service/tools_impl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -531,9 +532,10 @@ func searchTextInFileToolCallImpl(argsMap *map[string]interface{}) (string, erro
 	}
 	defer file.Close()
 
-	// Search for the text line by line
+	// Search for the text line by line using bufio.Reader to handle
+	// arbitrarily long lines without hitting a scanner token-size limit.
 	var result strings.Builder
-	scanner := bufio.NewScanner(file)
+	reader := bufio.NewReader(file)
 	lineNum := 0
 	foundCount := 0
 
@@ -551,9 +553,10 @@ func searchTextInFileToolCallImpl(argsMap *map[string]interface{}) (string, erro
 
 	result.WriteString(fmt.Sprintf("Search results for '%s' in %s (%s):\n", searchText, path, searchMode))
 
-	for scanner.Scan() {
+	for {
+		lineBytes, err := reader.ReadBytes('\n')
 		lineNum++
-		line := scanner.Text()
+		line := strings.TrimRight(string(lineBytes), "\r\n")
 
 		var matched bool
 		if useRegex {
@@ -568,10 +571,13 @@ func searchTextInFileToolCallImpl(argsMap *map[string]interface{}) (string, erro
 			foundCount++
 			result.WriteString(fmt.Sprintf("Line %d: %s\n", lineNum, line))
 		}
-	}
 
-	if err := scanner.Err(); err != nil {
-		return fmt.Sprintf("Error reading file %s: %v", path, err), nil
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Sprintf("Error reading file %s: %v", path, err), nil
+		}
 	}
 
 	if foundCount == 0 {

--- a/service/tools_impl_test.go
+++ b/service/tools_impl_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -238,6 +240,104 @@ func TestApplyWSNormalizedReplace(t *testing.T) {
 			}
 			if tt.wantFound && gotOut != tt.wantOut {
 				t.Errorf("output = %q, want %q", gotOut, tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestSearchTextInFileToolCallImpl(t *testing.T) {
+	// Create a temp directory for test files
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "search_test.txt")
+
+	// Create test content
+	content := "Hello World\nLine 2 contains some pattern: abc123def\nAnother line with pattern: ABC999DEF\nLast line is short.\n"
+	// To test the large line fix, append a 100KB line
+	largeLine := "HugeLine: " + strings.Repeat("x", 100*1024) + " endOfHuge\n"
+	content += largeLine
+
+	err := os.WriteFile(filePath, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		args            map[string]interface{}
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name: "exact match",
+			args: map[string]interface{}{
+				"path": filePath,
+				"text": "Hello World",
+			},
+			wantContains:    []string{"Search results for 'Hello World'", "exact match", "Line 1: Hello World", "Found 1 match(es)."},
+			wantNotContains: []string{"Line 2:", "Line 3:"},
+		},
+		{
+			name: "case insensitive match",
+			args: map[string]interface{}{
+				"path":             filePath,
+				"text":             "hello world",
+				"case_insensitive": true,
+			},
+			wantContains: []string{"Search results for 'hello world'", "case-insensitive", "Line 1: Hello World", "Found 1 match(es)."},
+		},
+		{
+			name: "regex match",
+			args: map[string]interface{}{
+				"path":  filePath,
+				"text":  `abc\d{3}def`,
+				"regex": true,
+			},
+			wantContains:    []string{"regex", "Line 2: Line 2 contains some pattern: abc123def", "Found 1 match(es)."},
+			wantNotContains: []string{"ABC999DEF"},
+		},
+		{
+			name: "regex case insensitive match",
+			args: map[string]interface{}{
+				"path":             filePath,
+				"text":             `abc\d{3}def`,
+				"regex":            true,
+				"case_insensitive": true,
+			},
+			wantContains: []string{"regex, case-insensitive", "Line 2: Line 2 contains some pattern: abc123def", "Line 3: Another line with pattern: ABC999DEF", "Found 2 match(es)."},
+		},
+		{
+			name: "no match",
+			args: map[string]interface{}{
+				"path": filePath,
+				"text": "nonexistent_pattern",
+			},
+			wantContains: []string{"No matches found."},
+		},
+		{
+			name: "large line match",
+			args: map[string]interface{}{
+				"path": filePath,
+				"text": "endOfHuge",
+			},
+			wantContains: []string{"Line 5: HugeLine:", "Found 1 match(es)."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := searchTextInFileToolCallImpl(&tt.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("got:\n%s\nwant to contain: %s", got, want)
+				}
+			}
+			for _, wantNot := range tt.wantNotContains {
+				if strings.Contains(got, wantNot) {
+					t.Errorf("got:\n%s\nwant NOT to contain: %s", got, wantNot)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This PR fixes issue #204 by increasing the buffer size for bufio.Scanner when reading session files that contain large image data.

Closes #204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large file content and data payloads.
  * Enhanced robustness of file reading operations.

* **Tests**
  * Added tests validating file reading with large data (2 MB+ payloads).
  * Added comprehensive tests for file search functionality including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->